### PR TITLE
Moved the constants to the dedicated class.

### DIFF
--- a/API_Reference.md
+++ b/API_Reference.md
@@ -1,5 +1,5 @@
 - [`Overview`](#overview)
-- [`Constants`](#constants)
+- [`libak_RestConstants class`](#restconstants-class)
   - [HTTP Status Codes](#http-status-codes)
   - [HTTP Headers](#http-headers)
   - [Content Types](#content-types)
@@ -82,30 +82,32 @@ The `libak_RestFramework` class provides a structured framework for building RES
 
 ![libak_RestFramework UML diagram](assets/RestFrameworkUML.png)
 
-## `Constants`
+## `libak_RestConstants class`
+
+The `libak_RestConstants` class contains all constant values used throughout the REST framework. This includes HTTP status codes, header names, content types, and error messages.
 
 ### HTTP Status Codes
 
-- `libak_RestFramework.HTTP_CODE_OK` (Integer): HTTP status code for a successful request (200).
-- `libak_RestFramework.HTTP_CODE_BAD_REQUEST` (Integer): HTTP status code for a bad request (400).
-- `libak_RestFramework.HTTP_CODE_NOT_FOUND` (Integer): HTTP status code for a not found resource (404).
-- `libak_RestFramework.HTTP_CODE_METHOD_NOT_ALLOWED` (Integer): HTTP status code for a method not allowed (405).
-- `libak_RestFramework.HTTP_CODE_INTERNAL_SERVER_ERROR` (Integer): HTTP status code for an internal server error (500).
+- `libak_RestConstants.HTTP_CODE_OK` (Integer): HTTP status code for a successful request (200).
+- `libak_RestConstants.HTTP_CODE_BAD_REQUEST` (Integer): HTTP status code for a bad request (400).
+- `libak_RestConstants.HTTP_CODE_NOT_FOUND` (Integer): HTTP status code for a not found resource (404).
+- `libak_RestConstants.HTTP_CODE_METHOD_NOT_ALLOWED` (Integer): HTTP status code for a method not allowed (405).
+- `libak_RestConstants.HTTP_CODE_INTERNAL_SERVER_ERROR` (Integer): HTTP status code for an internal server error (500).
 
 ### HTTP Headers
 
-- `libak_RestFramework.HEADER_NAME_CONTENT_TYPE` (String): The name of the HTTP header for specifying content type.
+- `libak_RestConstants.HEADER_NAME_CONTENT_TYPE` (String): The name of the HTTP header for specifying content type.
 
 ### Content Types
 
-- `libak_RestFramework.CONTENT_TYPE_APPLICATION_JSON` (String): Content type for JSON data.
-- `libak_RestFramework.CONTENT_TYPE_APPLICATION_PDF` (String): Content type for PDF data.
+- `libak_RestConstants.CONTENT_TYPE_APPLICATION_JSON` (String): Content type for JSON data.
+- `libak_RestConstants.CONTENT_TYPE_APPLICATION_PDF` (String): Content type for PDF data.
 
 ### Error Messages
 
-- `libak_RestFramework.ERROR_MESSAGE_INTERNAL_SERVER_ERROR` (String): Default error message for internal server errors.
-- `libak_RestFramework.ERROR_MESSAGE_INVALID_URI` (String): Error message for invalid URIs.
-- `libak_RestFramework.ERROR_MESSAGE_METHOD_NOT_ALLOWED` (String): Error message for unsupported HTTP methods.
+- `libak_RestConstants.ERROR_MESSAGE_INTERNAL_SERVER_ERROR` (String): Default error message for internal server errors.
+- `libak_RestConstants.ERROR_MESSAGE_INVALID_URI` (String): Error message for invalid URIs.
+- `libak_RestConstants.ERROR_MESSAGE_METHOD_NOT_ALLOWED` (String): Error message for unsupported HTTP methods.
 
 ## `Interfaces`
 

--- a/force-app/main/default/classes/libak_ErrorResponse.cls
+++ b/force-app/main/default/classes/libak_ErrorResponse.cls
@@ -63,6 +63,6 @@ public class libak_ErrorResponse implements libak_IRestResponse {
 	public void sendResponse() {
 		RestContext.response.statusCode = this.statusCode;
 		RestContext.response.responseBody = BLOB.valueOf(JSON.serialize(this));
-		RestContext.response.addHeader(libak_RestFramework.HEADER_NAME_CONTENT_TYPE, libak_RestFramework.CONTENT_TYPE_APPLICATION_JSON);
+		RestContext.response.addHeader(libak_RestConstants.HEADER_NAME_CONTENT_TYPE, libak_RestConstants.CONTENT_TYPE_APPLICATION_JSON);
 	}
 }

--- a/force-app/main/default/classes/libak_ErrorResponseFactory.cls
+++ b/force-app/main/default/classes/libak_ErrorResponseFactory.cls
@@ -4,8 +4,8 @@
  */
 public class libak_ErrorResponseFactory implements libak_IErrorResponseFactory {
 	private Map<String, Integer> httpStatusByErrorType = new Map<String, Integer>{
-		libak_RestFramework.InvalidUriException.class.getName() => libak_RestFramework.HTTP_CODE_BAD_REQUEST,
-		libak_RestFramework.MethodNotAllowedException.class.getName() => libak_RestFramework.HTTP_CODE_METHOD_NOT_ALLOWED
+		libak_RestFramework.InvalidUriException.class.getName() => libak_RestConstants.HTTP_CODE_BAD_REQUEST,
+		libak_RestFramework.MethodNotAllowedException.class.getName() => libak_RestConstants.HTTP_CODE_METHOD_NOT_ALLOWED
 	};
 
 	/**
@@ -19,8 +19,8 @@ public class libak_ErrorResponseFactory implements libak_IErrorResponseFactory {
 		return statusCode != null
 			? new libak_ErrorResponse(statusCode, exc)
 			: new libak_ErrorResponse(
-				libak_RestFramework.HTTP_CODE_INTERNAL_SERVER_ERROR,
-				libak_RestFramework.ERROR_MESSAGE_INTERNAL_SERVER_ERROR,
+				libak_RestConstants.HTTP_CODE_INTERNAL_SERVER_ERROR,
+				libak_RestConstants.ERROR_MESSAGE_INTERNAL_SERVER_ERROR,
 				exc
 			);
 	}

--- a/force-app/main/default/classes/libak_JsonResponse.cls
+++ b/force-app/main/default/classes/libak_JsonResponse.cls
@@ -11,7 +11,7 @@ public class libak_JsonResponse extends libak_SuccessResponse {
 	 */
 	public libak_JsonResponse(String data) {
 		super(data);
-		this.addHeader(libak_RestFramework.HEADER_NAME_CONTENT_TYPE, libak_RestFramework.CONTENT_TYPE_APPLICATION_JSON);
+		this.addHeader(libak_RestConstants.HEADER_NAME_CONTENT_TYPE, libak_RestConstants.CONTENT_TYPE_APPLICATION_JSON);
 	}
 
 	/**
@@ -21,7 +21,7 @@ public class libak_JsonResponse extends libak_SuccessResponse {
 	 */
 	public libak_JsonResponse(Object data) {
 		super(Blob.valueOf(JSON.serialize(data)));
-		this.addHeader(libak_RestFramework.HEADER_NAME_CONTENT_TYPE, libak_RestFramework.CONTENT_TYPE_APPLICATION_JSON);
+		this.addHeader(libak_RestConstants.HEADER_NAME_CONTENT_TYPE, libak_RestConstants.CONTENT_TYPE_APPLICATION_JSON);
 	}
 
 	/**
@@ -32,7 +32,7 @@ public class libak_JsonResponse extends libak_SuccessResponse {
 	 */
 	public libak_JsonResponse(Integer statusCode, String data) {
 		super(statusCode, data);
-		this.addHeader(libak_RestFramework.HEADER_NAME_CONTENT_TYPE, libak_RestFramework.CONTENT_TYPE_APPLICATION_JSON);
+		this.addHeader(libak_RestConstants.HEADER_NAME_CONTENT_TYPE, libak_RestConstants.CONTENT_TYPE_APPLICATION_JSON);
 	}
 
 	/**
@@ -43,6 +43,6 @@ public class libak_JsonResponse extends libak_SuccessResponse {
 	 */
 	public libak_JsonResponse(Integer statusCode, Object data) {
 		super(statusCode, Blob.valueOf(JSON.serialize(data)));
-		this.addHeader(libak_RestFramework.HEADER_NAME_CONTENT_TYPE, libak_RestFramework.CONTENT_TYPE_APPLICATION_JSON);
+		this.addHeader(libak_RestConstants.HEADER_NAME_CONTENT_TYPE, libak_RestConstants.CONTENT_TYPE_APPLICATION_JSON);
 	}
 }

--- a/force-app/main/default/classes/libak_RestConstants.cls
+++ b/force-app/main/default/classes/libak_RestConstants.cls
@@ -1,0 +1,24 @@
+/**
+ * The `libak_RestConstants` class contains all constant values used throughout the REST framework.
+ * This includes HTTP status codes, header names, content types, and error messages.
+ */
+public class libak_RestConstants {
+	// Constants for HTTP status codes
+	public static final Integer HTTP_CODE_OK = 200;
+	public static final Integer HTTP_CODE_BAD_REQUEST = 400;
+	public static final Integer HTTP_CODE_NOT_FOUND = 404;
+	public static final Integer HTTP_CODE_METHOD_NOT_ALLOWED = 405;
+	public static final Integer HTTP_CODE_INTERNAL_SERVER_ERROR = 500;
+
+	// Constants for HTTP headers
+	public static final String HEADER_NAME_CONTENT_TYPE = 'Content-Type';
+
+	// Constants for content types
+	public static final String CONTENT_TYPE_APPLICATION_JSON = 'application/json';
+	public static final String CONTENT_TYPE_APPLICATION_PDF = 'application/pdf';
+
+	// Constants for error messages
+	public static final String ERROR_MESSAGE_INTERNAL_SERVER_ERROR = 'Internal Server Error';
+	public static final String ERROR_MESSAGE_INVALID_URI = 'Invalid URI: ';
+	public static final String ERROR_MESSAGE_METHOD_NOT_ALLOWED = 'The {0} http method is not available for this resource: {1}.';
+}

--- a/force-app/main/default/classes/libak_RestConstants.cls-meta.xml
+++ b/force-app/main/default/classes/libak_RestConstants.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/libak_RestFramework.cls
+++ b/force-app/main/default/classes/libak_RestFramework.cls
@@ -4,25 +4,6 @@
  * for processing RESTful requests.
  */
 public class libak_RestFramework {
-	// Constants for HTTP status codes
-	public static final Integer HTTP_CODE_OK = 200;
-	public static final Integer HTTP_CODE_BAD_REQUEST = 400;
-	public static final Integer HTTP_CODE_NOT_FOUND = 404;
-	public static final Integer HTTP_CODE_METHOD_NOT_ALLOWED = 405;
-	public static final Integer HTTP_CODE_INTERNAL_SERVER_ERROR = 500;
-
-	// Constants for HTTP headers
-	public static final String HEADER_NAME_CONTENT_TYPE = 'Content-Type';
-
-	// Constants for content types
-	public static final String CONTENT_TYPE_APPLICATION_JSON = 'application/json';
-	public static final String CONTENT_TYPE_APPLICATION_PDF = 'application/pdf';
-
-	// Constants for error messages
-	public static final String ERROR_MESSAGE_INTERNAL_SERVER_ERROR = 'Internal Server Error';
-	public static final String ERROR_MESSAGE_INVALID_URI = 'Invalid URI: ';
-	public static final String ERROR_MESSAGE_METHOD_NOT_ALLOWED = 'The {0} http method is not available for this resource: {1}.';
-
 	/**
 	 * Handles an incoming REST request using the specified router.
 	 *

--- a/force-app/main/default/classes/libak_RestProcessor.cls
+++ b/force-app/main/default/classes/libak_RestProcessor.cls
@@ -225,7 +225,7 @@ public virtual class libak_RestProcessor {
 		List<String> uriItems = this.request.requestURI.substringAfter('/').split('/');
 		List<String> templateItems = this.uriTemplate.substringAfter('/').split('/');
 		if (uriItems.size() != templateItems.size()) {
-			throw new libak_RestFramework.InvalidUriException(libak_RestFramework.ERROR_MESSAGE_INVALID_URI + this.request.requestURI);
+			throw new libak_RestFramework.InvalidUriException(libak_RestConstants.ERROR_MESSAGE_INVALID_URI + this.request.requestURI);
 		}
 		this.uriParamsMap = new Map<String, String>();
 		while (!templateItems.isEmpty()) {
@@ -246,7 +246,7 @@ public virtual class libak_RestProcessor {
 	private void throwMethodNotAllowedException() {
 		throw new libak_RestFramework.MethodNotAllowedException(
 			String.format(
-				libak_RestFramework.ERROR_MESSAGE_METHOD_NOT_ALLOWED,
+				libak_RestConstants.ERROR_MESSAGE_METHOD_NOT_ALLOWED,
 				new List<String>{this.request.httpMethod, this.request.requestURI}
 			)
 		);

--- a/force-app/main/default/classes/libak_RestRouter.cls
+++ b/force-app/main/default/classes/libak_RestRouter.cls
@@ -74,7 +74,7 @@ public abstract class libak_RestRouter {
 					.useUriTemplate(route);
 			}
 		}
-		throw new libak_RestFramework.InvalidUriException(libak_RestFramework.ERROR_MESSAGE_INVALID_URI + request.requestURI);
+		throw new libak_RestFramework.InvalidUriException(libak_RestConstants.ERROR_MESSAGE_INVALID_URI + request.requestURI);
 	}
 
 	/**

--- a/force-app/main/default/classes/libak_SuccessResponse.cls
+++ b/force-app/main/default/classes/libak_SuccessResponse.cls
@@ -13,7 +13,7 @@ public virtual class libak_SuccessResponse implements libak_IRestResponse {
 	 * @param data The data to include in the response.
 	 */
 		public libak_SuccessResponse(String data) {
-		this(libak_RestFramework.HTTP_CODE_OK, Blob.valueOf(data));
+		this(libak_RestConstants.HTTP_CODE_OK, Blob.valueOf(data));
 	}
 
 	/**
@@ -22,7 +22,7 @@ public virtual class libak_SuccessResponse implements libak_IRestResponse {
 	 * @param data The data to include in the response.
 	 */
 	public libak_SuccessResponse(Blob data) {
-		this(libak_RestFramework.HTTP_CODE_OK, data);
+		this(libak_RestConstants.HTTP_CODE_OK, data);
 	}
 
 	/**

--- a/force-app/main/default/classes/tests/libak_TestErrorResponse.cls
+++ b/force-app/main/default/classes/tests/libak_TestErrorResponse.cls
@@ -5,7 +5,7 @@ public with sharing class libak_TestErrorResponse {
 	static void testErrorResponseInstance(){
 		RestContext.response = new RestResponse();
 		libak_IRestResponse response = new libak_ErrorResponse(
-			libak_RestFramework.HTTP_CODE_BAD_REQUEST,
+			libak_RestConstants.HTTP_CODE_BAD_REQUEST,
 			new libak_RestFramework.InvalidUriException('Bad Request')
 		);
 
@@ -16,18 +16,18 @@ public with sharing class libak_TestErrorResponse {
 		Test.stopTest();
 
 		System.assert(
-			RestContext.response.headers.containsKey(libak_RestFramework.HEADER_NAME_CONTENT_TYPE),
+			RestContext.response.headers.containsKey(libak_RestConstants.HEADER_NAME_CONTENT_TYPE),
 			'The response should have the "Content-Type" header.'
 		);
 		System.assertEquals(
-			libak_RestFramework.CONTENT_TYPE_APPLICATION_JSON,
-			RestContext.response.headers.get(libak_RestFramework.HEADER_NAME_CONTENT_TYPE),
+			libak_RestConstants.CONTENT_TYPE_APPLICATION_JSON,
+			RestContext.response.headers.get(libak_RestConstants.HEADER_NAME_CONTENT_TYPE),
 			'The "Content-Type" header should be "application/json"'
 		);
 		System.assertEquals(
-			libak_RestFramework.HTTP_CODE_BAD_REQUEST,
+			libak_RestConstants.HTTP_CODE_BAD_REQUEST,
 			RestContext.response.statusCode,
-			'The status code of response should be ' + libak_RestFramework.HTTP_CODE_BAD_REQUEST
+			'The status code of response should be ' + libak_RestConstants.HTTP_CODE_BAD_REQUEST
 		);
 		System.assertEquals(
 			Blob.valueOf(JSON.serialize(response)),

--- a/force-app/main/default/classes/tests/libak_TestErrorResponseFactory.cls
+++ b/force-app/main/default/classes/tests/libak_TestErrorResponseFactory.cls
@@ -14,16 +14,16 @@ public with sharing class libak_TestErrorResponseFactory {
 		Test.stopTest();
 
 		System.assert(
-			RestContext.response.headers.containsKey(libak_RestFramework.HEADER_NAME_CONTENT_TYPE),
+			RestContext.response.headers.containsKey(libak_RestConstants.HEADER_NAME_CONTENT_TYPE),
 			'The response should have the "Content-Type" header.'
 		);
 		System.assertEquals(
-			libak_RestFramework.CONTENT_TYPE_APPLICATION_JSON,
-			RestContext.response.headers.get(libak_RestFramework.HEADER_NAME_CONTENT_TYPE),
+			libak_RestConstants.CONTENT_TYPE_APPLICATION_JSON,
+			RestContext.response.headers.get(libak_RestConstants.HEADER_NAME_CONTENT_TYPE),
 			'The "Content-Type" header should be "application/json"'
 		);
 		System.assertEquals(
-			libak_RestFramework.HTTP_CODE_METHOD_NOT_ALLOWED,
+			libak_RestConstants.HTTP_CODE_METHOD_NOT_ALLOWED,
 			RestContext.response.statusCode,
 			'The status code of response should be 405'
 		);
@@ -48,16 +48,16 @@ public with sharing class libak_TestErrorResponseFactory {
 		Test.stopTest();
 
 		System.assert(
-			RestContext.response.headers.containsKey(libak_RestFramework.HEADER_NAME_CONTENT_TYPE),
+			RestContext.response.headers.containsKey(libak_RestConstants.HEADER_NAME_CONTENT_TYPE),
 			'The response should have the "Content-Type" header.'
 		);
 		System.assertEquals(
-			libak_RestFramework.CONTENT_TYPE_APPLICATION_JSON,
-			RestContext.response.headers.get(libak_RestFramework.HEADER_NAME_CONTENT_TYPE),
+			libak_RestConstants.CONTENT_TYPE_APPLICATION_JSON,
+			RestContext.response.headers.get(libak_RestConstants.HEADER_NAME_CONTENT_TYPE),
 			'The "Content-Type" header should be "application/json"'
 		);
 		System.assertEquals(
-			libak_RestFramework.HTTP_CODE_INTERNAL_SERVER_ERROR,
+			libak_RestConstants.HTTP_CODE_INTERNAL_SERVER_ERROR,
 			RestContext.response.statusCode,
 			'The status code of response should be 500'
 		);

--- a/force-app/main/default/classes/tests/libak_TestJsonResponse.cls
+++ b/force-app/main/default/classes/tests/libak_TestJsonResponse.cls
@@ -18,16 +18,16 @@ public with sharing class libak_TestJsonResponse {
 		Test.stopTest();
 
 		System.assert(
-			RestContext.response.headers.containsKey(libak_RestFramework.HEADER_NAME_CONTENT_TYPE),
+			RestContext.response.headers.containsKey(libak_RestConstants.HEADER_NAME_CONTENT_TYPE),
 			'The response should have the "Content-Type" header.'
 		);
 		System.assertEquals(
-			libak_RestFramework.CONTENT_TYPE_APPLICATION_JSON,
-			RestContext.response.headers.get(libak_RestFramework.HEADER_NAME_CONTENT_TYPE),
+			libak_RestConstants.CONTENT_TYPE_APPLICATION_JSON,
+			RestContext.response.headers.get(libak_RestConstants.HEADER_NAME_CONTENT_TYPE),
 			'The "Content-Type" header should be "application/json"'
 		);
 		System.assertEquals(
-			libak_RestFramework.HTTP_CODE_OK,
+			libak_RestConstants.HTTP_CODE_OK,
 			RestContext.response.statusCode,
 			'The status code of response should be 200'
 		);
@@ -51,16 +51,16 @@ public with sharing class libak_TestJsonResponse {
 
 		String stringResponseData = JSON.serialize(TEST_RESPONSE_DATA);
 		System.assert(
-			RestContext.response.headers.containsKey(libak_RestFramework.HEADER_NAME_CONTENT_TYPE),
+			RestContext.response.headers.containsKey(libak_RestConstants.HEADER_NAME_CONTENT_TYPE),
 			'The response should have the "Content-Type" header.'
 		);
 		System.assertEquals(
-			libak_RestFramework.CONTENT_TYPE_APPLICATION_JSON,
-			RestContext.response.headers.get(libak_RestFramework.HEADER_NAME_CONTENT_TYPE),
+			libak_RestConstants.CONTENT_TYPE_APPLICATION_JSON,
+			RestContext.response.headers.get(libak_RestConstants.HEADER_NAME_CONTENT_TYPE),
 			'The "Content-Type" header should be "application/json"'
 		);
 		System.assertEquals(
-			libak_RestFramework.HTTP_CODE_OK,
+			libak_RestConstants.HTTP_CODE_OK,
 			RestContext.response.statusCode,
 			'The status code of response should be 200'
 		);
@@ -75,7 +75,7 @@ public with sharing class libak_TestJsonResponse {
 	static void testConstructorStatusCodeAndStringData(){
 		RestContext.response = new RestResponse();
 		String stringResponseData = JSON.serialize(TEST_RESPONSE_DATA);
-		libak_IRestResponse response = new libak_JsonResponse(libak_RestFramework.HTTP_CODE_BAD_REQUEST, stringResponseData);
+		libak_IRestResponse response = new libak_JsonResponse(libak_RestConstants.HTTP_CODE_BAD_REQUEST, stringResponseData);
 
 		Test.startTest();
 
@@ -84,16 +84,16 @@ public with sharing class libak_TestJsonResponse {
 		Test.stopTest();
 
 		System.assert(
-			RestContext.response.headers.containsKey(libak_RestFramework.HEADER_NAME_CONTENT_TYPE),
+			RestContext.response.headers.containsKey(libak_RestConstants.HEADER_NAME_CONTENT_TYPE),
 			'The response should have the "Content-Type" header.'
 		);
 		System.assertEquals(
-			libak_RestFramework.CONTENT_TYPE_APPLICATION_JSON,
-			RestContext.response.headers.get(libak_RestFramework.HEADER_NAME_CONTENT_TYPE),
+			libak_RestConstants.CONTENT_TYPE_APPLICATION_JSON,
+			RestContext.response.headers.get(libak_RestConstants.HEADER_NAME_CONTENT_TYPE),
 			'The "Content-Type" header should be "application/json"'
 		);
 		System.assertEquals(
-			libak_RestFramework.HTTP_CODE_BAD_REQUEST,
+			libak_RestConstants.HTTP_CODE_BAD_REQUEST,
 			RestContext.response.statusCode,
 			'The status code of response should be 400'
 		);
@@ -107,7 +107,7 @@ public with sharing class libak_TestJsonResponse {
 	@IsTest
 	static void testConstructorStatusCodeAndObjectData(){
 		RestContext.response = new RestResponse();
-		libak_IRestResponse response = new libak_JsonResponse(libak_RestFramework.HTTP_CODE_BAD_REQUEST, TEST_RESPONSE_DATA);
+		libak_IRestResponse response = new libak_JsonResponse(libak_RestConstants.HTTP_CODE_BAD_REQUEST, TEST_RESPONSE_DATA);
 
 		Test.startTest();
 
@@ -117,16 +117,16 @@ public with sharing class libak_TestJsonResponse {
 
 		String stringResponseData = JSON.serialize(TEST_RESPONSE_DATA);
 		System.assert(
-			RestContext.response.headers.containsKey(libak_RestFramework.HEADER_NAME_CONTENT_TYPE),
+			RestContext.response.headers.containsKey(libak_RestConstants.HEADER_NAME_CONTENT_TYPE),
 			'The response should have the "Content-Type" header.'
 		);
 		System.assertEquals(
-			libak_RestFramework.CONTENT_TYPE_APPLICATION_JSON,
-			RestContext.response.headers.get(libak_RestFramework.HEADER_NAME_CONTENT_TYPE),
+			libak_RestConstants.CONTENT_TYPE_APPLICATION_JSON,
+			RestContext.response.headers.get(libak_RestConstants.HEADER_NAME_CONTENT_TYPE),
 			'The "Content-Type" header should be "application/json"'
 		);
 		System.assertEquals(
-			libak_RestFramework.HTTP_CODE_BAD_REQUEST,
+			libak_RestConstants.HTTP_CODE_BAD_REQUEST,
 			RestContext.response.statusCode,
 			'The status code of response should be 400'
 		);
@@ -150,16 +150,16 @@ public with sharing class libak_TestJsonResponse {
 
 		String stringResponseData = JSON.serialize(TEST_RESPONSE_DATA);
 		System.assert(
-			RestContext.response.headers.containsKey(libak_RestFramework.HEADER_NAME_CONTENT_TYPE),
+			RestContext.response.headers.containsKey(libak_RestConstants.HEADER_NAME_CONTENT_TYPE),
 			'The response should have the "Content-Type" header.'
 		);
 		System.assertEquals(
-			libak_RestFramework.CONTENT_TYPE_APPLICATION_JSON,
-			RestContext.response.headers.get(libak_RestFramework.HEADER_NAME_CONTENT_TYPE),
+			libak_RestConstants.CONTENT_TYPE_APPLICATION_JSON,
+			RestContext.response.headers.get(libak_RestConstants.HEADER_NAME_CONTENT_TYPE),
 			'The "Content-Type" header should be "application/json"'
 		);
 		System.assertEquals(
-			libak_RestFramework.HTTP_CODE_OK,
+			libak_RestConstants.HTTP_CODE_OK,
 			RestContext.response.statusCode,
 			'The status code of response should be 200'
 		);

--- a/force-app/main/default/classes/tests/libak_TestRestFramework.cls
+++ b/force-app/main/default/classes/tests/libak_TestRestFramework.cls
@@ -18,7 +18,7 @@ public with sharing class libak_TestRestFramework {
 		Test.stopTest();
 
 		System.assertEquals(
-			libak_RestFramework.HTTP_CODE_METHOD_NOT_ALLOWED,
+			libak_RestConstants.HTTP_CODE_METHOD_NOT_ALLOWED,
 			RestContext.response.statusCode,
 			'The status code of response should be 405'
 		);
@@ -38,7 +38,7 @@ public with sharing class libak_TestRestFramework {
 		Test.stopTest();
 
 		System.assertEquals(
-			libak_RestFramework.HTTP_CODE_METHOD_NOT_ALLOWED,
+			libak_RestConstants.HTTP_CODE_METHOD_NOT_ALLOWED,
 			RestContext.response.statusCode,
 			'The status code of response should be 405'
 		);
@@ -58,7 +58,7 @@ public with sharing class libak_TestRestFramework {
 		Test.stopTest();
 
 		System.assertEquals(
-			libak_RestFramework.HTTP_CODE_METHOD_NOT_ALLOWED,
+			libak_RestConstants.HTTP_CODE_METHOD_NOT_ALLOWED,
 			RestContext.response.statusCode,
 			'The status code of response should be 405'
 		);
@@ -78,7 +78,7 @@ public with sharing class libak_TestRestFramework {
 		Test.stopTest();
 
 		System.assertEquals(
-			libak_RestFramework.HTTP_CODE_INTERNAL_SERVER_ERROR,
+			libak_RestConstants.HTTP_CODE_INTERNAL_SERVER_ERROR,
 			RestContext.response.statusCode,
 			'The status code of response should be 500'
 		);
@@ -88,7 +88,7 @@ public with sharing class libak_TestRestFramework {
 			libak_ErrorResponse.class
 		);
 		System.assertEquals(
-			libak_RestFramework.ERROR_MESSAGE_INTERNAL_SERVER_ERROR,
+			libak_RestConstants.ERROR_MESSAGE_INTERNAL_SERVER_ERROR,
 			errorResponse.summary,
 			'The summary property of response is wrong.'
 		);

--- a/force-app/main/default/classes/tests/libak_TestRestProcessor.cls
+++ b/force-app/main/default/classes/tests/libak_TestRestProcessor.cls
@@ -81,16 +81,16 @@ public with sharing class libak_TestRestProcessor {
 	static void testGetHeader(){
 		RestRequest request = new RestRequest();
 		request.requestURI = '/testRestRouter/uri_param';
-		request.addHeader(libak_RestFramework.HEADER_NAME_CONTENT_TYPE, libak_RestFramework.CONTENT_TYPE_APPLICATION_JSON);
+		request.addHeader(libak_RestConstants.HEADER_NAME_CONTENT_TYPE, libak_RestConstants.CONTENT_TYPE_APPLICATION_JSON);
 		libak_RestProcessor processor = prepareDefaultRestProcessor(request);
 
 		Test.startTest();
 
-		String header = processor.getHeader(libak_RestFramework.HEADER_NAME_CONTENT_TYPE);
+		String header = processor.getHeader(libak_RestConstants.HEADER_NAME_CONTENT_TYPE);
 
 		Test.stopTest();
 
-		System.assertEquals(libak_RestFramework.CONTENT_TYPE_APPLICATION_JSON, header, 'The header is wrong.');
+		System.assertEquals(libak_RestConstants.CONTENT_TYPE_APPLICATION_JSON, header, 'The header is wrong.');
 	}
 
 	private static libak_RestProcessor prepareDefaultRestProcessor(RestRequest request) {
@@ -116,16 +116,16 @@ public with sharing class libak_TestRestProcessor {
 		Test.stopTest();
 
 		System.assert(
-			RestContext.response.headers.containsKey(libak_RestFramework.HEADER_NAME_CONTENT_TYPE),
+			RestContext.response.headers.containsKey(libak_RestConstants.HEADER_NAME_CONTENT_TYPE),
 			'The response should have the "Content-Type" header.'
 		);
 		System.assertEquals(
-			libak_RestFramework.CONTENT_TYPE_APPLICATION_JSON,
-			RestContext.response.headers.get(libak_RestFramework.HEADER_NAME_CONTENT_TYPE),
+			libak_RestConstants.CONTENT_TYPE_APPLICATION_JSON,
+			RestContext.response.headers.get(libak_RestConstants.HEADER_NAME_CONTENT_TYPE),
 			'The "Content-Type" header should be "application/json"'
 		);
 		System.assertEquals(
-			libak_RestFramework.HTTP_CODE_METHOD_NOT_ALLOWED,
+			libak_RestConstants.HTTP_CODE_METHOD_NOT_ALLOWED,
 			RestContext.response.statusCode,
 			'The status code of response should be 405'
 		);

--- a/force-app/main/default/classes/tests/libak_TestRestRouter.cls
+++ b/force-app/main/default/classes/tests/libak_TestRestRouter.cls
@@ -104,7 +104,7 @@ public with sharing class libak_TestRestRouter {
 			throw new TestCustomException('Go in to catch block.');
 		} catch (Exception exc) {
 			System.assertEquals(
-				libak_RestFramework.ERROR_MESSAGE_INVALID_URI + request.requestURI,
+				libak_RestConstants.ERROR_MESSAGE_INVALID_URI + request.requestURI,
 				exc.getMessage(),
 				'Wrong exception message'
 			);


### PR DESCRIPTION
## Summary
Moved all static constants from `libak_RestFramework` to a new dedicated `libak_RestConstants` class to improve code organization and separation of concerns.

## Changes
- **New Class**: Created `libak_RestConstants` class containing all HTTP status codes, header names, content types, and error messages
- **Updated Classes**: Refactored `libak_RestFramework` and all dependent classes to reference `libak_RestConstants` instead
- **Updated Tests**: Modified all test classes to use the new constant references
- **Documentation**: Updated `API_Reference.md` to reflect the new class structure

## Impact
- ✅ Better separation of concerns - constants are now in a dedicated class
- ✅ Improved maintainability - constants have a single source of truth
- ✅ No breaking changes to functionality - all tests pass
- ⚠️ **Breaking change**: External code referencing `libak_RestFramework.HTTP_CODE_*` or similar constants must update to `libak_RestConstants.*`

## Files Changed
- **New**: `libak_RestConstants.cls` and metadata
- **Modified**: 7 framework classes, 6 test classes
- **Documentation**: `API_Reference.md`

---

This is a refactoring improvement that enhances code organization while maintaining all existing functionality.
